### PR TITLE
Fix always true IsBlockValueValid IsTreasuryBlock check

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -190,8 +190,8 @@ bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue, CAmount nMin
     }
 
 	
-	if (IsTreasuryBlock(nHeight) <= 308000)
-    {
+	if (IsTreasuryBlock(nHeight) && nHeight <= 308000)
+        {
 		return true;
 	}
 

--- a/src/version.h
+++ b/src/version.h
@@ -15,7 +15,7 @@
 // Initial Rewards Fix on 72001 by TFinch
 // Exchange version, GUI update with chart 72004 TFinch
 // Min Stake Amount changed to 15 coins 72005 TFinch
-static const int PROTOCOL_VERSION = 72008;
+static const int PROTOCOL_VERSION = 72009;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -25,7 +25,7 @@ static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 72007;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 72008;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 72009;
 
 static const int MIN_PEER_VERSION_FIXED_SIGTIME = 72006;
 


### PR DESCRIPTION
Fixes the block value check & bumps up protocol version
![](https://camo.githubusercontent.com/98bed138280a41b2e8dca7c845bebf63381a0bff/68747470733a2f2f692e696d6775722e636f6d2f6c64554d7a30632e706e67)