### PR TITLE
Fix peers refusing connection

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -77,7 +77,7 @@ enum WalletFeature {
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
 
-    FEATURE_LATEST = 61000
+    FEATURE_LATEST = 72009
 };
 
 enum AvailableCoinsType {


### PR DESCRIPTION
Wallets couldn't synchronise due to the protocol not been updated by the wallet.