### PR TITLE
Don't return an invalid state when shutting down the wallet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3167,9 +3167,14 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
 
     // Ensure that accumulator checkpoints are valid and in the same state as this instance of the chain
     AccumulatorMap mapAccumulators(GetZerocoinParams(pindex->nHeight));
-    if (!ValidateAccumulatorCheckpoint(block, pindex, mapAccumulators))
-        return state.DoS(100, error("%s: Failed to validate accumulator checkpoint for block=%s height=%d", __func__,
+    if (!ValidateAccumulatorCheckpoint(block, pindex, mapAccumulators)){
+	    if (!ShutdownRequested()){
+		    return state.DoS(100, error("%s: Failed to validate accumulator checkpoint for block=%s height=%d", __func__,
                                     block.GetHash().GetHex(), pindex->nHeight), REJECT_INVALID, "bad-acc-checkpoint");
+	    }
+	    return error("%s: Failed to validate accumulator checkpoint for block=%s height=%d because wallet is shutting down", __func__,
+                block.GetHash().GetHex(), pindex->nHeight);
+    }
 #endif
             if (!control.Wait())
                 return state.DoS(100, false);


### PR DESCRIPTION
When the shutdown process is started, it is possible that the call to
`ValidateAccumulatorCheckpoint()` in `ConnectBlock()` will fail. Instead
 of returning an invalid state, which causes the block to pass through
 `InvalidChainFound()`, just return a stateless error if a shutdown has
 been requested.

It's a fix from Pivx:  https://github.com/PIVX-Project/PIVX/pull/865/commits/8126729c7800d801f0f067d9a2257b8ad74c1a9f